### PR TITLE
Update jackson-databind to v2.9.9

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -354,7 +354,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.8</version>
+        <version>2.9.9</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
CVE-2019-12086 More information
moderate severity
Vulnerable versions: >= 2.0.0, < 2.9.9
Patched version: 2.9.9
A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.x before 2.9.9. When Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint, the service has the mysql-connector-java jar (8.0.14 or earlier) in the classpath, and an attacker can host a crafted MySQL server reachable by the victim, an attacker can send a crafted JSON message that allows them to read arbitrary local files on the server. This occurs because of missing com.mysql.cj.jdbc.admin.MiniAdmin validation.

https://nvd.nist.gov/vuln/detail/CVE-2019-12086